### PR TITLE
Keil warning fix for _ASSERT() macro

### DIFF
--- a/include/macro.h
+++ b/include/macro.h
@@ -65,6 +65,6 @@
  */
 #define _MAP(f, ...) _EVAL(_MAP1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
 
-#define _ASSERT(x) (1/(!!(x)) ? (x) : (x))
+#define _ASSERT(x) ((1/(!!(x))) ? (x) : (x))
 
 #endif /* __MACRO_H__ */


### PR DESCRIPTION
Bugfix for Keil warning: operator '?:' has lower precedence than '/'; '/' will be evaluated first [-Wparentheses].
_ASSERT() macro in file macro.h had wrong precedence of operators